### PR TITLE
Update tail_ correctly in circular_buffer::push_back

### DIFF
--- a/src/chapter_08/main.cpp
+++ b/src/chapter_08/main.cpp
@@ -106,7 +106,8 @@ namespace n801
          }
          else if (!full())
          {
-            data_[++tail_] = value;
+            tail_ = (tail_ + 1) % N;
+            data_[tail_] = value;
             size_++;
          }
          else
@@ -576,16 +577,22 @@ int main()
          assert(b[1] == 2);
          assert(b[2] == 3);
 
-         b.pop_front();
+         assert(b.pop_front() == 1);
          assert(b.size() == 2);
          assert(b[0] == 2);
          assert(b[1] == 3);
 
-         b.pop_front();
+         assert(b.pop_front() == 2);
          assert(b.size() == 1);
          assert(b[0] == 3);
+         
+         b.push_back(4)
+         assert(b.size() == 2);
+         assert(b[0] == 3);
+         assert(b[1] == 4);
 
-         b.pop_front();
+         assert(b.pop_front() == 3);
+         assert(b.pop_front() == 4);
          assert(b.size() == 0);
       }
 


### PR DESCRIPTION
push_back adds element out of bound for a circular buffer [ _ _ 3 ] when head and tail poits to '3' How to reproduce:
  circular_buffer<int, 3> cb {{1,2,3}};
  assert(cb.pop_front() == 1);
  assert(cb.pop_front() == 2);
  cb.push_back(4);
  assert(cb[0] == 3);
  assert(cb[1] == 4); // <<- '4' pushes to tail_=3

This commit updates tail_ according to circular buffer expectations